### PR TITLE
fix youtube url detection

### DIFF
--- a/tests/manual/inject_urls_test.py
+++ b/tests/manual/inject_urls_test.py
@@ -3,7 +3,7 @@
 
 from tests.manual.test_helper import run_tests
 
-text = "This is my website: https://www.jrodal.com/ and this is one of my posts: https://www.jrodal.com/posts/how-to-deploy-rocket-rust-web-app-on-vps/"
+text = "This is my website: https://www.jrodal.com/ and this is one of my posts: https://www.jrodal.com/posts/how-to-deploy-rocket-rust-web-app-on-vps/ and this is a yt video: https://www.youtube.com/watch?v=--khbXchTeE"  # noqa
 
 if __name__ == "__main__":
     run_tests(text)

--- a/tldrwl/summarize.py
+++ b/tldrwl/summarize.py
@@ -20,7 +20,7 @@ class Summarizer(AiInterface):
         self._summarizer = text_summarizer or Gpt35TurboTextSummarizer()
 
     async def _transform_text(self, text: str) -> str:
-        if YoutubeTransformer.get_video_id(text):
+        if YoutubeTransformer.is_youtube_url(text):
             self._logger.debug(f"Using YoutubeSummarizer on {text}")
             return await YoutubeTransformer(text).get_text()
         elif WebpageTransformer.is_url(text):

--- a/tldrwl/transformers/youtube_transformer.py
+++ b/tldrwl/transformers/youtube_transformer.py
@@ -11,6 +11,7 @@ from youtube_transcript_api.formatters import TextFormatter  # pyright: ignore
 from tldrwl.transformers.transformer import Transformer
 
 from tldrwl.exception import TldrwlVideoUrlParsingException
+from tldrwl.transformers.webpage_transformer import WebpageTransformer
 
 
 class YoutubeTransformer(Transformer):
@@ -22,6 +23,10 @@ class YoutubeTransformer(Transformer):
         super().__init__()
         self._url = url
         self._logger = logging.getLogger(__name__)
+
+    @classmethod
+    def is_youtube_url(cls, url: str) -> bool:
+        return WebpageTransformer.is_url(url) and cls.get_video_id(url) is not None
 
     @classmethod
     def get_video_id(cls, url: str) -> Optional[str]:


### PR DESCRIPTION
Fix a bug where the youtube URL detection was matching if there was a youtube URL somewhere in the text, rather than being the only thing in the text.

The consequence of this is that you could have an arbitrarily long text, and if there was a single youtube URL, that is all you would summarize.

With this fix, the URL matching behaves as expected